### PR TITLE
test: add node backward-compat regression coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.4",
+        "@playwright/test": "^1.60.0",
         "@tscircuit/alphabet": "0.0.23",
         "@types/bun": "^1.2.23",
         "@types/readable-stream": "^4.0.21",
@@ -111,6 +112,8 @@
     "@jsquash/png": ["@jsquash/png@3.1.1", "", {}, "sha512-C10pc+0H6j0h8fENOfnGOvkXCmvpSQTDGlfGd0sHphZhPSGTyLjIrHba0FaZZdsKqA/wlmhYicUHb92vfZphaw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.52.3", "", { "os": "android", "cpu": "arm" }, "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw=="],
 
@@ -476,6 +479,10 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -645,6 +652,8 @@
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "build": "tsup-node ./lib/index.ts --format esm --dts",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "test": "bun test"
+    "test": "bun test",
+    "test:playwright": "playwright test"
   },
   "type": "module",
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
+    "@playwright/test": "^1.60.0",
     "@tscircuit/alphabet": "0.0.23",
     "@types/bun": "^1.2.23",
     "@types/readable-stream": "^4.0.21",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./playwright",
+  testMatch: "**/*.pw.ts",
+  timeout: 120_000,
+  expect: {
+    timeout: 30_000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "bun x vite --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "list",
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: "http://localhost:5050",
     trace: "on-first-retry",
   },
   projects: [
@@ -23,9 +23,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "bun x vite --host 127.0.0.1 --port 4173",
-    url: "http://127.0.0.1:4173",
-    reuseExistingServer: true,
+    command: "PORT=5050 bun run start",
+    url: "http://localhost:5050",
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 })

--- a/playwright/browser-compat.html
+++ b/playwright/browser-compat.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PoppyGL Browser Compatibility Test</title>
+  </head>
+  <body>
+    <script type="module">
+      window.__poppyglCompat = { status: "running" }
+
+      try {
+        const globalsBeforeImport = {
+          hasBufferGlobal: typeof globalThis.Buffer !== "undefined",
+          hasProcessGlobal: typeof globalThis.process !== "undefined",
+        }
+
+        const { renderGLTFToPNGBuffer } = await import("/lib/index.ts")
+        const emptyGLTF = JSON.stringify({
+          asset: { version: "2.0" },
+          scenes: [{ nodes: [] }],
+          scene: 0,
+        })
+
+        const renderOptions = {
+          width: 96,
+          height: 72,
+          grid: { size: 8 },
+          camPos: [8, 6, 8],
+          lookAt: [0, 0, 0],
+        }
+
+        const inMemoryPng = await renderGLTFToPNGBuffer(emptyGLTF, renderOptions)
+        const urlPng = await renderGLTFToPNGBuffer(
+          "/tests/basics/soic8.gltf",
+          renderOptions,
+        )
+
+        let browserPathError = ""
+        try {
+          await renderGLTFToPNGBuffer("tests/basics/soic8.gltf", renderOptions)
+        } catch (error) {
+          browserPathError =
+            error instanceof Error ? error.message : String(error)
+        }
+
+        window.__poppyglCompat = {
+          status: "done",
+          globalsBeforeImport,
+          inMemory: {
+            isUint8Array: inMemoryPng instanceof Uint8Array,
+            constructorName: inMemoryPng.constructor.name,
+            length: inMemoryPng.length,
+          },
+          url: {
+            isUint8Array: urlPng instanceof Uint8Array,
+            constructorName: urlPng.constructor.name,
+            length: urlPng.length,
+          },
+          browserPathError,
+        }
+      } catch (error) {
+        window.__poppyglCompat = {
+          status: "error",
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/playwright/browser-compat.pw.ts
+++ b/playwright/browser-compat.pw.ts
@@ -1,40 +1,39 @@
 import { expect, test } from "@playwright/test"
 
 // Enable this when the root browser entrypoint is browser-safe and backward-compatible.
-test.skip(
-  "browser root export renders without Node globals and rejects filesystem paths separately",
-  async ({ page }) => {
-    await page.goto("/playwright/browser-compat.html")
+test.skip("browser root export renders without Node globals and rejects filesystem paths separately", async ({
+  page,
+}) => {
+  await page.goto("/playwright/browser-compat.html")
 
-    await expect
-      .poll(async () => {
-        return await page.evaluate(
-          () =>
-            (window as Window & { __poppyglCompat?: any }).__poppyglCompat
-              ?.status ?? null,
-        )
-      })
-      .not.toBe("running")
+  await expect
+    .poll(async () => {
+      return await page.evaluate(
+        () =>
+          (window as Window & { __poppyglCompat?: any }).__poppyglCompat
+            ?.status ?? null,
+      )
+    })
+    .not.toBe("running")
 
-    const result = await page.evaluate(
-      () => (window as Window & { __poppyglCompat?: any }).__poppyglCompat,
-    )
-    expect(result.status).toBe("done")
+  const result = await page.evaluate(
+    () => (window as Window & { __poppyglCompat?: any }).__poppyglCompat,
+  )
+  expect(result.status).toBe("done")
 
-    expect(result.globalsBeforeImport.hasBufferGlobal).toBe(false)
-    expect(result.globalsBeforeImport.hasProcessGlobal).toBe(false)
+  expect(result.globalsBeforeImport.hasBufferGlobal).toBe(false)
+  expect(result.globalsBeforeImport.hasProcessGlobal).toBe(false)
 
-    expect(result.inMemory.isUint8Array).toBe(true)
-    expect(result.inMemory.constructorName).toBe("Uint8Array")
-    expect(result.inMemory.length).toBeGreaterThan(100)
+  expect(result.inMemory.isUint8Array).toBe(true)
+  expect(result.inMemory.constructorName).toBe("Uint8Array")
+  expect(result.inMemory.length).toBeGreaterThan(100)
 
-    expect(result.url.isUint8Array).toBe(true)
-    expect(result.url.constructorName).toBe("Uint8Array")
-    expect(result.url.length).toBeGreaterThan(100)
+  expect(result.url.isUint8Array).toBe(true)
+  expect(result.url.constructorName).toBe("Uint8Array")
+  expect(result.url.length).toBeGreaterThan(100)
 
-    expect(result.browserPathError).toContain(
-      "could not parse the input as GLTF JSON",
-    )
-    expect(result.browserPathError).toContain("fetchable URL")
-  },
-)
+  expect(result.browserPathError).toContain(
+    "could not parse the input as GLTF JSON",
+  )
+  expect(result.browserPathError).toContain("fetchable URL")
+})

--- a/playwright/browser-compat.pw.ts
+++ b/playwright/browser-compat.pw.ts
@@ -1,39 +1,44 @@
 import { expect, test } from "@playwright/test"
 
 // Enable this when the root browser entrypoint is browser-safe and backward-compatible.
-test.skip("browser root export renders without Node globals and rejects filesystem paths separately", async ({
-  page,
-}) => {
-  await page.goto("/playwright/browser-compat.html")
+test.skip(
+  "browser root export renders without Node globals and rejects filesystem paths separately",
+  async ({ page }) => {
+    const fixtureId = encodeURIComponent(
+      JSON.stringify({ path: "site/examples/browser-compat.page.tsx" }),
+    )
 
-  await expect
-    .poll(async () => {
-      return await page.evaluate(
-        () =>
-          (window as Window & { __poppyglCompat?: any }).__poppyglCompat
-            ?.status ?? null,
-      )
-    })
-    .not.toBe("running")
+    await page.goto(`/renderer.html?fixtureId=${fixtureId}&locked=true`)
 
-  const result = await page.evaluate(
-    () => (window as Window & { __poppyglCompat?: any }).__poppyglCompat,
-  )
-  expect(result.status).toBe("done")
+    await expect(
+      page.getByRole("heading", { name: "Browser Compatibility Fixture" }),
+    ).toBeVisible()
 
-  expect(result.globalsBeforeImport.hasBufferGlobal).toBe(false)
-  expect(result.globalsBeforeImport.hasProcessGlobal).toBe(false)
+    await expect
+      .poll(async () => {
+        return await page.getByTestId("compat-state").textContent()
+      })
+      .not.toContain('"status": "running"')
 
-  expect(result.inMemory.isUint8Array).toBe(true)
-  expect(result.inMemory.constructorName).toBe("Uint8Array")
-  expect(result.inMemory.length).toBeGreaterThan(100)
+    const result = JSON.parse(
+      (await page.getByTestId("compat-state").textContent()) ?? "null",
+    )
+    expect(result.status).toBe("done")
 
-  expect(result.url.isUint8Array).toBe(true)
-  expect(result.url.constructorName).toBe("Uint8Array")
-  expect(result.url.length).toBeGreaterThan(100)
+    expect(result.globalsBeforeImport.hasBufferGlobal).toBe(false)
+    expect(result.globalsBeforeImport.hasProcessGlobal).toBe(false)
 
-  expect(result.browserPathError).toContain(
-    "could not parse the input as GLTF JSON",
-  )
-  expect(result.browserPathError).toContain("fetchable URL")
-})
+    expect(result.inMemory.isUint8Array).toBe(true)
+    expect(result.inMemory.constructorName).toBe("Uint8Array")
+    expect(result.inMemory.length).toBeGreaterThan(100)
+
+    expect(result.url.isUint8Array).toBe(true)
+    expect(result.url.constructorName).toBe("Uint8Array")
+    expect(result.url.length).toBeGreaterThan(100)
+
+    expect(result.browserPathError).toContain(
+      "could not parse the input as GLTF JSON",
+    )
+    expect(result.browserPathError).toContain("fetchable URL")
+  },
+)

--- a/playwright/browser-compat.pw.ts
+++ b/playwright/browser-compat.pw.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test"
+
+// Enable this when the root browser entrypoint is browser-safe and backward-compatible.
+test.skip(
+  "browser root export renders without Node globals and rejects filesystem paths separately",
+  async ({ page }) => {
+    await page.goto("/playwright/browser-compat.html")
+
+    await expect
+      .poll(async () => {
+        return await page.evaluate(
+          () =>
+            (window as Window & { __poppyglCompat?: any }).__poppyglCompat
+              ?.status ?? null,
+        )
+      })
+      .not.toBe("running")
+
+    const result = await page.evaluate(
+      () => (window as Window & { __poppyglCompat?: any }).__poppyglCompat,
+    )
+    expect(result.status).toBe("done")
+
+    expect(result.globalsBeforeImport.hasBufferGlobal).toBe(false)
+    expect(result.globalsBeforeImport.hasProcessGlobal).toBe(false)
+
+    expect(result.inMemory.isUint8Array).toBe(true)
+    expect(result.inMemory.constructorName).toBe("Uint8Array")
+    expect(result.inMemory.length).toBeGreaterThan(100)
+
+    expect(result.url.isUint8Array).toBe(true)
+    expect(result.url.constructorName).toBe("Uint8Array")
+    expect(result.url.length).toBeGreaterThan(100)
+
+    expect(result.browserPathError).toContain(
+      "could not parse the input as GLTF JSON",
+    )
+    expect(result.browserPathError).toContain("fetchable URL")
+  },
+)

--- a/playwright/browser-compat.pw.ts
+++ b/playwright/browser-compat.pw.ts
@@ -1,44 +1,43 @@
 import { expect, test } from "@playwright/test"
 
 // Enable this when the root browser entrypoint is browser-safe and backward-compatible.
-test.skip(
-  "browser root export renders without Node globals and rejects filesystem paths separately",
-  async ({ page }) => {
-    const fixtureId = encodeURIComponent(
-      JSON.stringify({ path: "site/examples/browser-compat.page.tsx" }),
-    )
+test.skip("browser root export renders without Node globals and rejects filesystem paths separately", async ({
+  page,
+}) => {
+  const fixtureId = encodeURIComponent(
+    JSON.stringify({ path: "site/examples/browser-compat.page.tsx" }),
+  )
 
-    await page.goto(`/renderer.html?fixtureId=${fixtureId}&locked=true`)
+  await page.goto(`/renderer.html?fixtureId=${fixtureId}&locked=true`)
 
-    await expect(
-      page.getByRole("heading", { name: "Browser Compatibility Fixture" }),
-    ).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Browser Compatibility Fixture" }),
+  ).toBeVisible()
 
-    await expect
-      .poll(async () => {
-        return await page.getByTestId("compat-state").textContent()
-      })
-      .not.toContain('"status": "running"')
+  await expect
+    .poll(async () => {
+      return await page.getByTestId("compat-state").textContent()
+    })
+    .not.toContain('"status": "running"')
 
-    const result = JSON.parse(
-      (await page.getByTestId("compat-state").textContent()) ?? "null",
-    )
-    expect(result.status).toBe("done")
+  const result = JSON.parse(
+    (await page.getByTestId("compat-state").textContent()) ?? "null",
+  )
+  expect(result.status).toBe("done")
 
-    expect(result.globalsBeforeImport.hasBufferGlobal).toBe(false)
-    expect(result.globalsBeforeImport.hasProcessGlobal).toBe(false)
+  expect(result.globalsBeforeImport.hasBufferGlobal).toBe(false)
+  expect(result.globalsBeforeImport.hasProcessGlobal).toBe(false)
 
-    expect(result.inMemory.isUint8Array).toBe(true)
-    expect(result.inMemory.constructorName).toBe("Uint8Array")
-    expect(result.inMemory.length).toBeGreaterThan(100)
+  expect(result.inMemory.isUint8Array).toBe(true)
+  expect(result.inMemory.constructorName).toBe("Uint8Array")
+  expect(result.inMemory.length).toBeGreaterThan(100)
 
-    expect(result.url.isUint8Array).toBe(true)
-    expect(result.url.constructorName).toBe("Uint8Array")
-    expect(result.url.length).toBeGreaterThan(100)
+  expect(result.url.isUint8Array).toBe(true)
+  expect(result.url.constructorName).toBe("Uint8Array")
+  expect(result.url.length).toBeGreaterThan(100)
 
-    expect(result.browserPathError).toContain(
-      "could not parse the input as GLTF JSON",
-    )
-    expect(result.browserPathError).toContain("fetchable URL")
-  },
-)
+  expect(result.browserPathError).toContain(
+    "could not parse the input as GLTF JSON",
+  )
+  expect(result.browserPathError).toContain("fetchable URL")
+})

--- a/site/examples/browser-compat.page.tsx
+++ b/site/examples/browser-compat.page.tsx
@@ -52,7 +52,10 @@ export default function BrowserCompatPage() {
           scene: 0,
         })
 
-        const inMemoryPng = await renderGLTFToPNGBuffer(emptyGLTF, renderOptions)
+        const inMemoryPng = await renderGLTFToPNGBuffer(
+          emptyGLTF,
+          renderOptions,
+        )
         const urlPng = await renderGLTFToPNGBuffer(
           "/tests/basics/soic8.gltf",
           renderOptions,

--- a/site/examples/browser-compat.page.tsx
+++ b/site/examples/browser-compat.page.tsx
@@ -1,34 +1,56 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PoppyGL Browser Compatibility Test</title>
-  </head>
-  <body>
-    <script type="module">
-      window.__poppyglCompat = { status: "running" }
+import React, { useEffect, useState } from "react"
+import { renderGLTFToPNGBuffer } from "../../lib"
 
+type CompatState =
+  | { status: "running" }
+  | {
+      status: "done"
+      globalsBeforeImport: {
+        hasBufferGlobal: boolean
+        hasProcessGlobal: boolean
+      }
+      inMemory: {
+        isUint8Array: boolean
+        constructorName: string
+        length: number
+      }
+      url: {
+        isUint8Array: boolean
+        constructorName: string
+        length: number
+      }
+      browserPathError: string
+    }
+  | {
+      status: "error"
+      message: string
+      stack?: string
+    }
+
+const renderOptions = {
+  width: 96,
+  height: 72,
+  grid: { size: 8 },
+  camPos: [8, 6, 8] as [number, number, number],
+  lookAt: [0, 0, 0] as [number, number, number],
+}
+
+export default function BrowserCompatPage() {
+  const [state, setState] = useState<CompatState>({ status: "running" })
+
+  useEffect(() => {
+    const run = async () => {
       try {
         const globalsBeforeImport = {
           hasBufferGlobal: typeof globalThis.Buffer !== "undefined",
           hasProcessGlobal: typeof globalThis.process !== "undefined",
         }
 
-        const { renderGLTFToPNGBuffer } = await import("/lib/index.ts")
         const emptyGLTF = JSON.stringify({
           asset: { version: "2.0" },
           scenes: [{ nodes: [] }],
           scene: 0,
         })
-
-        const renderOptions = {
-          width: 96,
-          height: 72,
-          grid: { size: 8 },
-          camPos: [8, 6, 8],
-          lookAt: [0, 0, 0],
-        }
 
         const inMemoryPng = await renderGLTFToPNGBuffer(emptyGLTF, renderOptions)
         const urlPng = await renderGLTFToPNGBuffer(
@@ -44,7 +66,7 @@
             error instanceof Error ? error.message : String(error)
         }
 
-        window.__poppyglCompat = {
+        setState({
           status: "done",
           globalsBeforeImport,
           inMemory: {
@@ -58,14 +80,23 @@
             length: urlPng.length,
           },
           browserPathError,
-        }
+        })
       } catch (error) {
-        window.__poppyglCompat = {
+        setState({
           status: "error",
           message: error instanceof Error ? error.message : String(error),
           stack: error instanceof Error ? error.stack : undefined,
-        }
+        })
       }
-    </script>
-  </body>
-</html>
+    }
+
+    run()
+  }, [])
+
+  return (
+    <main style={{ fontFamily: "monospace", padding: 16 }}>
+      <h1>Browser Compatibility Fixture</h1>
+      <pre data-testid="compat-state">{JSON.stringify(state, null, 2)}</pre>
+    </main>
+  )
+}

--- a/tests/backward-compat/node-api.test.ts
+++ b/tests/backward-compat/node-api.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import {
+  encodePNGToBuffer,
+  pureImageFactory,
+  renderGLTFToPNGBuffer,
+} from "../../lib"
+
+function expectPngSignature(bytes: Uint8Array) {
+  expect(bytes[0]).toBe(0x89)
+  expect(bytes[1]).toBe(0x50)
+  expect(bytes[2]).toBe(0x4e)
+  expect(bytes[3]).toBe(0x47)
+}
+
+test("root renderGLTFToPNGBuffer keeps supporting filesystem paths in Node", async () => {
+  const pngBuffer = await renderGLTFToPNGBuffer("./tests/basics/soic8.gltf", {
+    width: 96,
+    height: 96,
+  })
+
+  expect(Buffer.isBuffer(pngBuffer)).toBe(true)
+  expect(pngBuffer.length).toBeGreaterThan(100)
+  expectPngSignature(pngBuffer)
+})
+
+test("encodePNGToBuffer keeps returning a Node Buffer at runtime", async () => {
+  const image = pureImageFactory(2, 2)
+  const pngBuffer = await encodePNGToBuffer(image)
+
+  expect(Buffer.isBuffer(pngBuffer)).toBe(true)
+  expect(pngBuffer.length).toBeGreaterThan(10)
+  expectPngSignature(pngBuffer)
+})


### PR DESCRIPTION
This pull request introduces Playwright-based browser compatibility testing and adds a new browser compatibility fixture, alongside improvements to the test setup and backward compatibility tests for the Node.js API. The main changes are grouped below:

<img width="1467" height="815" alt="image" src="https://github.com/user-attachments/assets/dd253bae-466d-4898-8c9e-3c7af975e37c" />

**Browser compatibility testing infrastructure:**

* Added Playwright as a dev dependency and introduced a new `test:playwright` script in `package.json` to enable browser-based testing.
* Added a Playwright configuration file (`playwright.config.ts`) to specify test directory, matching pattern, browser settings, and web server startup for browser tests.

**Browser compatibility fixture:**

* Added a new browser compatibility test page (`browser-compat.page.tsx`) that checks for absence of Node globals, correct rendering of PNG buffers, and error handling for filesystem paths in the browser.
* Added a Playwright test (`browser-compat.pw.ts`) to automate and validate the browser compatibility fixture, ensuring correct behavior in a browser environment.

**Node.js API backward compatibility tests:**

* Added new Bun-based tests (`node-api.test.ts`) to verify that the Node.js API still supports filesystem paths and returns Node Buffers as expected.