### PR TITLE
Use Uint8Array-first byte helpers in shared runtime paths

### DIFF
--- a/lib/gltf/resourceUtils.ts
+++ b/lib/gltf/resourceUtils.ts
@@ -1,11 +1,12 @@
 import { PassThrough } from "readable-stream"
 import * as PImage from "pureimage"
 import type { BitmapLike } from "../image/createUint8Bitmap"
+import { base64ToUint8Array } from "../utils/bytes"
 
 export function bufferFromDataURI(uri: string): Uint8Array {
   const match = uri.match(/^data:.*?;base64,(.*)$/)
   if (!match) throw new Error(`Unsupported data URI: ${uri.slice(0, 64)}...`)
-  return Buffer.from(match[1]!, "base64")
+  return base64ToUint8Array(match[1]!)
 }
 
 export function isPNG(filenameOrUri: string) {
@@ -39,7 +40,7 @@ export function detectMimeTypeFromBuffer(
 
 export function bufferToStream(buf: Uint8Array) {
   const stream = new PassThrough()
-  stream.end(Buffer.from(buf))
+  ;(stream.end as (chunk: Uint8Array) => void)(buf)
   return stream
 }
 

--- a/lib/image/encodePNGToBuffer.ts
+++ b/lib/image/encodePNGToBuffer.ts
@@ -1,15 +1,25 @@
 import { PassThrough } from "readable-stream"
 import * as PImage from "pureimage"
+import {
+  concatUint8Arrays,
+  toUint8Array,
+  uint8ArrayToNodeBuffer,
+} from "../utils/bytes"
 import type { BitmapLike } from "./createUint8Bitmap"
 
 export async function encodePNGToBuffer(image: BitmapLike): Promise<Buffer> {
   const passThrough = new PassThrough()
-  const chunks: Buffer[] = []
-  passThrough.on("data", (chunk: any) => {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
-  })
+  const chunks: Uint8Array[] = []
+  passThrough.on(
+    "data",
+    (chunk: Uint8Array | ArrayBuffer | ArrayBufferView) => {
+      chunks.push(toUint8Array(chunk))
+    },
+  )
   const resultPromise = new Promise<Buffer>((resolve, reject) => {
-    passThrough.on("end", () => resolve(Buffer.concat(chunks)))
+    passThrough.on("end", () => {
+      resolve(uint8ArrayToNodeBuffer(concatUint8Arrays(chunks)))
+    })
     passThrough.on("error", reject)
   })
   await PImage.encodePNGToStream(image as any, passThrough as any)

--- a/lib/utils/bytes.ts
+++ b/lib/utils/bytes.ts
@@ -1,0 +1,50 @@
+type NodeBufferConstructor = {
+  from(
+    input: Uint8Array | ArrayBuffer | ArrayBufferView | string,
+    encoding?: string,
+  ): Buffer
+}
+
+function getNodeBuffer(): NodeBufferConstructor {
+  const maybeBuffer = (globalThis as { Buffer?: NodeBufferConstructor }).Buffer
+  if (!maybeBuffer) {
+    throw new Error("Node Buffer API is not available in this runtime.")
+  }
+  return maybeBuffer
+}
+
+export function toUint8Array(
+  chunk: Uint8Array | ArrayBuffer | ArrayBufferView,
+): Uint8Array {
+  if (chunk instanceof Uint8Array) return chunk
+  if (chunk instanceof ArrayBuffer) return new Uint8Array(chunk)
+  return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+}
+
+export function concatUint8Arrays(chunks: readonly Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((length, chunk) => length + chunk.length, 0)
+  const result = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    result.set(chunk, offset)
+    offset += chunk.length
+  }
+  return result
+}
+
+export function base64ToUint8Array(base64: string): Uint8Array {
+  if (typeof globalThis.atob === "function") {
+    const binary = globalThis.atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes
+  }
+
+  return new Uint8Array(getNodeBuffer().from(base64, "base64"))
+}
+
+export function uint8ArrayToNodeBuffer(bytes: Uint8Array): Buffer {
+  return getNodeBuffer().from(bytes)
+}

--- a/tests/backward-compat/node-api.test.ts
+++ b/tests/backward-compat/node-api.test.ts
@@ -83,5 +83,6 @@ test("encodePNGToBuffer keeps returning a Node Buffer at runtime", async () => {
   const image = pureImageFactory(2, 2)
   const pngBuffer = await encodePNGToBuffer(image)
 
+  expect(pngBuffer).toBeInstanceOf(Uint8Array)
   expectPngBuffer(pngBuffer, 10)
 })

--- a/tests/utils/bytes.test.ts
+++ b/tests/utils/bytes.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import {
+  base64ToUint8Array,
+  concatUint8Arrays,
+  toUint8Array,
+  uint8ArrayToNodeBuffer,
+} from "../../lib/utils/bytes"
+
+test("concatUint8Arrays combines chunks into a Uint8Array", () => {
+  const bytes = concatUint8Arrays([new Uint8Array([1, 2]), new Uint8Array([3])])
+
+  expect(bytes).toBeInstanceOf(Uint8Array)
+  expect(Array.from(bytes)).toEqual([1, 2, 3])
+})
+
+test("toUint8Array preserves sliced view ranges", () => {
+  const backing = new Uint8Array([9, 1, 2, 8])
+  const bytes = toUint8Array(backing.subarray(1, 3))
+
+  expect(bytes).toBeInstanceOf(Uint8Array)
+  expect(Array.from(bytes)).toEqual([1, 2])
+})
+
+test("base64ToUint8Array decodes exact bytes", () => {
+  const bytes = base64ToUint8Array("AQID")
+
+  expect(bytes).toBeInstanceOf(Uint8Array)
+  expect(Array.from(bytes)).toEqual([1, 2, 3])
+})
+
+test("uint8ArrayToNodeBuffer returns a real Node Buffer", () => {
+  const bytes = uint8ArrayToNodeBuffer(new Uint8Array([1, 2, 3]))
+
+  expect(Buffer.isBuffer(bytes)).toBe(true)
+  expect(Array.from(bytes)).toEqual([1, 2, 3])
+})


### PR DESCRIPTION
## Summary

This is PR 3 of the multi-PR browser-safety plan for public rendering entrypoints.

This PR refactors shared byte handling to use `Uint8Array`-first helpers instead of direct `Buffer.from`, `Buffer.concat`, and `Buffer.isBuffer` usage in library runtime paths, while preserving existing Node `Buffer` return behavior.

## Changes

- Added shared byte utilities for normalizing, concatenating, and decoding byte data as `Uint8Array`.
- Updated `encodePNGToBuffer` to collect PNG stream chunks as `Uint8Array` internally.
- Updated GLTF resource utilities to decode data URIs without direct `Buffer.from`.
- Kept Node compatibility by converting back to `Buffer` only at the public API boundary.
- Added focused byte helper tests and strengthened backward compatibility coverage.

## Validation

- `rg -n "Buffer\\.from|Buffer\\.concat|Buffer\\.isBuffer" lib -S`
- `bun test`
- `bun run format:check`
- `bun run build`
