### PR TITLE
feat: add wireframe render mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const png = await renderGLTFToPNGBufferFromGLBBuffer(glb, {
 
 - `width`/`height` (default `512`): output resolution in pixels.
 - `supersampling`: render at `width * supersampling` / `height * supersampling`, then downsample (default `1`).
+- `renderMode`: `"solid"` (default) or `"wireframe"` to draw triangle mesh edges.
 - `fov`: vertical field of view in degrees (defaults to `35`).
 - `camPos` and `lookAt`: override the auto-framed camera position and target.
 - `up`: choose the world-up axis for the camera with `"y+" | "y-" | "x+" | "x-" | "z+" | "z-"`.

--- a/cli/runCLI.ts
+++ b/cli/runCLI.ts
@@ -13,7 +13,7 @@ export async function runCLI() {
   const argv = parseCliArgs(process.argv.slice(2))
   if (argv._.length === 0) {
     console.error(
-      "Usage: poppygl model.gltf [--out out.png] [--w 960] [--h 540] [--fov 60] [--supersampling 2]",
+      "Usage: poppygl model.gltf [--out out.png] [--w 960] [--h 540] [--fov 60] [--supersampling 2] [--wireframe]",
     )
     process.exit(1)
   }
@@ -57,6 +57,7 @@ export async function runCLI() {
     Number.isFinite(supersamplingParsed) && supersamplingParsed > 0
       ? supersamplingParsed
       : DEFAULT_RENDER_OPTIONS.supersampling
+  const renderMode = argv.wireframe ? "wireframe" : "solid"
 
   await renderGLTFToPNGFile(gltfPath, outPath, {
     width,
@@ -69,6 +70,7 @@ export async function runCLI() {
     cull,
     gamma,
     supersampling,
+    renderMode,
   })
   console.log(`Wrote ${outPath} (${width}x${height})`)
 }

--- a/lib/render/SoftwareRenderer.ts
+++ b/lib/render/SoftwareRenderer.ts
@@ -4,17 +4,17 @@ import { computeSmoothNormals } from "../gltf/computeSmoothNormals"
 import type { DrawCall, Material } from "../gltf/types"
 import {
   type BitmapLike,
+  createUint8Bitmap,
   type ImageFactory,
   type MutableRGBA,
-  createUint8Bitmap,
 } from "../image/createUint8Bitmap"
+import { clamp } from "../utils/clamp"
+import { mulColor } from "../utils/mulColor"
+import { srgbEncodeLinear01 } from "../utils/srgbEncodeLinear01"
 import {
   DEFAULT_LIGHT_DIR,
   DEFAULT_RENDER_OPTIONS,
 } from "./getDefaultRenderOptions"
-import { mulColor } from "../utils/mulColor"
-import { srgbEncodeLinear01 } from "../utils/srgbEncodeLinear01"
-import { clamp } from "../utils/clamp"
 
 export interface LightSettings {
   dir: readonly [number, number, number]
@@ -183,6 +183,37 @@ export class SoftwareRenderer {
         z += zinc
       }
     }
+  }
+
+  drawMeshWireframe(mesh: DrawCall, camera: Camera, gammaOut = true) {
+    const vertexCount = (mesh.positions.length / 3) | 0
+    const sourceIndices =
+      mesh.indices ??
+      (() => {
+        const generated = new Uint32Array(vertexCount)
+        for (let i = 0; i < vertexCount; i += 1) generated[i] = i
+        return generated
+      })()
+    const edgeIndices: number[] = []
+
+    for (let i = 0; i + 2 < sourceIndices.length; i += 3) {
+      const i0 = sourceIndices[i + 0]!
+      const i1 = sourceIndices[i + 1]!
+      const i2 = sourceIndices[i + 2]!
+      edgeIndices.push(i0, i1, i1, i2, i2, i0)
+    }
+
+    if (edgeIndices.length === 0) return
+
+    this.drawLines(
+      {
+        ...mesh,
+        indices: new Uint32Array(edgeIndices),
+        mode: 1,
+      },
+      camera,
+      gammaOut,
+    )
   }
 
   sampleTextureNearest(
@@ -433,7 +464,7 @@ export class SoftwareRenderer {
           let r = baseColor[0] * lit
           let g = baseColor[1] * lit
           let b = baseColor[2] * lit
-          let a = baseColor[3]
+          const a = baseColor[3]
 
           // Handle material transparency
           const alphaMode = material.alphaMode ?? "OPAQUE"

--- a/lib/render/getDefaultRenderOptions.ts
+++ b/lib/render/getDefaultRenderOptions.ts
@@ -44,6 +44,7 @@ export interface RenderOptions {
   width: number
   height: number
   supersampling: number
+  renderMode: "solid" | "wireframe"
   fov: number
   cull: boolean
   gamma: boolean
@@ -67,6 +68,7 @@ export const DEFAULT_RENDER_OPTIONS: RenderOptions = {
   width: 800,
   height: 600,
   supersampling: 1,
+  renderMode: "solid",
   fov: 60,
   cull: true,
   gamma: true,

--- a/lib/render/renderDrawCalls.ts
+++ b/lib/render/renderDrawCalls.ts
@@ -127,6 +127,8 @@ export function renderDrawCalls(
     for (const dc of dcs) {
       if (dc.mode === 1) {
         renderer.drawLines(dc, camera, options.gamma)
+      } else if (options.renderMode === "wireframe") {
+        renderer.drawMeshWireframe(dc, camera, options.gamma)
       } else {
         renderer.drawMesh(
           dc,

--- a/tests/basics/wireframe.test.ts
+++ b/tests/basics/wireframe.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { mat4 } from "gl-matrix"
+import type { DrawCall } from "../../lib/gltf/types"
+import { renderDrawCalls } from "../../lib/render/renderDrawCalls"
+
+const countOpaquePixels = (data: Uint8ClampedArray | Uint8Array) => {
+  let count = 0
+  for (let i = 3; i < data.length; i += 4) {
+    if (data[i]! > 0) count += 1
+  }
+  return count
+}
+
+test("wireframe render mode draws mesh edges without filling faces", () => {
+  const square: DrawCall = {
+    positions: new Float32Array([-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    uvs: null,
+    indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    model: mat4.create(),
+    material: {
+      baseColorFactor: [1, 0, 0, 1],
+      baseColorTexture: null,
+    },
+  }
+
+  const baseOptions = {
+    width: 96,
+    height: 96,
+    camPos: [0, 0, 4] as const,
+    lookAt: [0, 0, 0] as const,
+    cull: false,
+    gamma: false,
+  }
+
+  const solid = renderDrawCalls([square], baseOptions)
+  const wireframe = renderDrawCalls([square], {
+    ...baseOptions,
+    renderMode: "wireframe",
+  })
+
+  const solidOpaque = countOpaquePixels(solid.bitmap.data)
+  const wireframeOpaque = countOpaquePixels(wireframe.bitmap.data)
+
+  expect(wireframeOpaque).toBeGreaterThan(0)
+  expect(solidOpaque).toBeGreaterThan(wireframeOpaque * 4)
+})


### PR DESCRIPTION
Fixes #19

Summary
- Add a `renderMode: solid | wireframe` render option with `solid` as the default.
- Render triangle meshes as edge lists when `renderMode` is `wireframe`.
- Expose `--wireframe` in the CLI and document the option.

Verification
- `bun test tests\basics\wireframe.test.ts`
- `bun x biome check lib\render\getDefaultRenderOptions.ts lib\render\renderDrawCalls.ts lib\render\SoftwareRenderer.ts cli\runCLI.ts tests\basics\wireframe.test.ts README.md` (passes with existing warnings)
- `bun x tsc --noEmit`
- `git diff --check`