### PR TITLE
feat: add antialias render option

### DIFF
--- a/cli/runCLI.ts
+++ b/cli/runCLI.ts
@@ -13,7 +13,7 @@ export async function runCLI() {
   const argv = parseCliArgs(process.argv.slice(2))
   if (argv._.length === 0) {
     console.error(
-      "Usage: poppygl model.gltf [--out out.png] [--w 960] [--h 540] [--fov 60] [--supersampling 2]",
+      "Usage: poppygl model.gltf [--out out.png] [--w 960] [--h 540] [--fov 60] [--antialias] [--supersampling 2]",
     )
     process.exit(1)
   }
@@ -44,14 +44,16 @@ export async function runCLI() {
     parseVec3(argv.light) ?? (DEFAULT_LIGHT_DIR as [number, number, number])
   const camPos = parseVec3(argv.cam)
   const lookAt = parseVec3(argv.look)
-  const cull = argv.noCull ? false : true
-  const gamma = argv.noGamma ? false : true
+  const cull = !argv.noCull
+  const gamma = !argv.noGamma
   const supersamplingArg =
     typeof argv.supersampling === "string"
       ? argv.supersampling
       : typeof argv.ss === "string"
         ? argv.ss
-        : `${DEFAULT_RENDER_OPTIONS.supersampling}`
+        : argv.antialias
+          ? "2"
+          : `${DEFAULT_RENDER_OPTIONS.supersampling}`
   const supersamplingParsed = Number.parseInt(supersamplingArg, 10)
   const supersampling =
     Number.isFinite(supersamplingParsed) && supersamplingParsed > 0
@@ -68,6 +70,7 @@ export async function runCLI() {
     lookAt,
     cull,
     gamma,
+    antialias: Boolean(argv.antialias),
     supersampling,
   })
   console.log(`Wrote ${outPath} (${width}x${height})`)

--- a/lib/render/getDefaultRenderOptions.ts
+++ b/lib/render/getDefaultRenderOptions.ts
@@ -43,6 +43,7 @@ export function hexToRgb(hex: string): [number, number, number] | null {
 export interface RenderOptions {
   width: number
   height: number
+  antialias: boolean
   supersampling: number
   fov: number
   cull: boolean
@@ -66,6 +67,7 @@ export type RenderOptionsInput = Partial<RenderOptions>
 export const DEFAULT_RENDER_OPTIONS: RenderOptions = {
   width: 800,
   height: 600,
+  antialias: false,
   supersampling: 1,
   fov: 60,
   cull: true,

--- a/lib/render/resolveRenderOptions.ts
+++ b/lib/render/resolveRenderOptions.ts
@@ -1,7 +1,7 @@
 import {
-  DEFAULT_RENDER_OPTIONS,
   type CameraRotation,
   type CameraUp,
+  DEFAULT_RENDER_OPTIONS,
   type RenderOptions,
   type RenderOptionsInput,
 } from "./getDefaultRenderOptions"
@@ -32,11 +32,14 @@ function resolveCameraRotation(
 export function resolveRenderOptions(
   options: RenderOptionsInput = {},
 ): RenderOptions {
+  const supersamplingInput = options.supersampling
+  const hasExplicitSupersampling = typeof supersamplingInput === "number"
   const supersampling =
-    typeof options.supersampling === "number" &&
-    Number.isFinite(options.supersampling)
-      ? Math.max(1, Math.floor(options.supersampling))
-      : DEFAULT_RENDER_OPTIONS.supersampling
+    hasExplicitSupersampling && Number.isFinite(supersamplingInput)
+      ? Math.max(1, Math.floor(supersamplingInput))
+      : options.antialias
+        ? 2
+        : DEFAULT_RENDER_OPTIONS.supersampling
 
   return {
     ...DEFAULT_RENDER_OPTIONS,

--- a/tests/basics/resolve-render-options.test.ts
+++ b/tests/basics/resolve-render-options.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { resolveRenderOptions } from "../../lib/render/resolveRenderOptions"
+
+test("antialias enables 2x supersampling by default", () => {
+  const options = resolveRenderOptions({ antialias: true })
+
+  expect(options.antialias).toBe(true)
+  expect(options.supersampling).toBe(2)
+})
+
+test("explicit supersampling overrides antialias default", () => {
+  const options = resolveRenderOptions({ antialias: true, supersampling: 3 })
+
+  expect(options.antialias).toBe(true)
+  expect(options.supersampling).toBe(3)
+})


### PR DESCRIPTION
Fixes #20

## Summary
- Add an `antialias` render option that enables 2x supersampling through the existing downsample path.
- Keep explicit `supersampling` / `ss` values as the higher-priority override.
- Add `--antialias` to the CLI usage/options and cover option resolution with tests.

## Verification
- `bun test tests\basics\resolve-render-options.test.ts`
- `bun x @biomejs/biome check cli\runCLI.ts lib\render\getDefaultRenderOptions.ts lib\render\resolveRenderOptions.ts tests\basics\resolve-render-options.test.ts`
- `bun run build`
- `git diff --check`