### PR TITLE
Fix browser 3D PNG rendering by removing Node-only PoppyGL exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Render GLTF files to PNG images in completely native JavaScript without WebGL/Op
 Give poppygl a `.gltf` or `.glb` URL and it will fetch every referenced buffer/texture, rasterize the scene, and hand back a PNG buffer.
 
 ```ts
-import { renderGLTFToPNGBufferFromURL } from "poppygl"
+import { renderGLTFToPNGFromURL } from "poppygl"
 import { writeFile } from "node:fs/promises"
 
-const png = await renderGLTFToPNGBufferFromURL(
+const png = await renderGLTFToPNGFromURL(
   "https://models.babylonjs.com/DamagedHelmet.glb",
   {
     width: 800,
@@ -28,14 +28,14 @@ await writeFile("DamagedHelmet.png", png)
 
 ## Render from an in-memory GLB buffer
 
-Already have the `.glb` bytes (for example, uploaded by a user or read from disk)? Send the buffer straight to `renderGLTFToPNGBufferFromGLBBuffer` and receive the PNG output.
+Already have the `.glb` bytes (for example, uploaded by a user or read from disk)? Send the buffer straight to `renderGLTFToPNGFromGLB` and receive the PNG output.
 
 ```ts
 import { readFile } from "node:fs/promises"
-import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
+import { renderGLTFToPNGFromGLB } from "poppygl"
 
 const glb = await readFile("DamagedHelmet.glb")
-const png = await renderGLTFToPNGBufferFromGLBBuffer(glb, {
+const png = await renderGLTFToPNGFromGLB(glb, {
   width: 1024,
   height: 768,
 })
@@ -43,11 +43,11 @@ const png = await renderGLTFToPNGBufferFromGLBBuffer(glb, {
 // write or return the PNG buffer
 ```
 
-> This helper expects every referenced buffer/image to be embedded in the GLB (the usual single-file package). If the asset links out to external resources, load it with `renderGLTFToPNGBufferFromURL` instead so poppygl can fetch the extras.
+> This helper expects every referenced buffer/image to be embedded in the GLB (the usual single-file package). If the asset links out to external resources, load it with `renderGLTFToPNGFromURL` instead so poppygl can fetch the extras.
 
 ## Render options
 
-`renderGLTFToPNGBufferFromURL` accepts the same render options as the lower-level APIs:
+`renderGLTFToPNGFromURL` accepts the same render options as the lower-level APIs:
 
 - `width`/`height` (default `512`): output resolution in pixels.
 - `supersampling`: render at `width * supersampling` / `height * supersampling`, then downsample (default `1`).
@@ -76,8 +76,8 @@ import {
   bufferFromDataURI,
   createSceneFromGLTF,
   decodeImageFromBuffer,
-  encodePNGToBuffer,
-  pureImageFactory,
+  encodePNG,
+  createUint8Bitmap,
   renderSceneFromGLTF,
 } from "poppygl"
 import gltfJson from "./CesiumMan.gltf.json" assert { type: "json" }
@@ -105,8 +105,8 @@ const images = await Promise.all(
 )
 
 const scene = createSceneFromGLTF(gltfJson, { buffers, images })
-const { bitmap } = renderSceneFromGLTF(scene, { width: 512, height: 512 }, pureImageFactory)
-const png = await encodePNGToBuffer(bitmap)
+const { bitmap } = renderSceneFromGLTF(scene, { width: 512, height: 512 }, createUint8Bitmap)
+const png = await encodePNG(bitmap)
 ```
 
 The only contract is that `buffers` is an array of `Uint8Array` instances and `images` is an array of `BitmapLike` textures (PNG and JPEG are supported out of the box via `decodeImageFromBuffer`).
@@ -116,7 +116,7 @@ The only contract is that `buffers` is an array of `Uint8Array` instances and `i
 - `loadGLTFWithResourcesFromURL` returns `{ gltf, resources }` if you prefer to inspect or cache the parsed data before rendering.
 - `createSceneFromGLTF` builds draw calls ready for the software rasterizer.
 - `computeSmoothNormals` and `computeWorldAABB` expose useful preprocessing helpers.
-- `pureImageFactory` allocates the `pureimage` bitmap implementation used by the renderer.
-- `encodePNGToBuffer` packs any `BitmapLike` into a PNG buffer that can be written to disk or served over the network.
+- `createUint8Bitmap` allocates a portable in-memory bitmap used by the renderer.
+- `encodePNG` packs any `BitmapLike` into a `Uint8Array` PNG that can be written to disk or served over the network.
 
 Happy rendering!

--- a/cli/renderGLTFToPNGBuffer.ts
+++ b/cli/renderGLTFToPNGBuffer.ts
@@ -1,9 +1,6 @@
-import {
-  createSceneFromGLTF,
-  encodePNGToBuffer,
-  pureImageFactory,
-  renderSceneFromGLTF,
-} from "../lib/index"
+import { createSceneFromGLTF, renderSceneFromGLTF } from "../lib/index"
+import { encodePNGToBuffer } from "../lib/image/encodePNGToBuffer"
+import { pureImageFactory } from "../lib/image/pureImageFactory"
 import type { RenderOptionsInput } from "../lib/render/getDefaultRenderOptions"
 import { loadGLTFWithResources } from "./loadGLTFWithResources"
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,9 +42,7 @@ export type {
   MutableRGBA,
   RGBA,
 } from "./image/createUint8Bitmap"
-export { pureImageFactory } from "./image/pureImageFactory"
 export { encodePNG } from "./image/encodePNG"
-export { encodePNGToBuffer } from "./image/encodePNGToBuffer"
 
 export {
   type CameraRotation,
@@ -67,19 +65,6 @@ export {
   renderGLTFToPNGFromGLB,
   type RenderGLTFToPNGFromGLBOptions,
 } from "./render/renderGLTFToPNGFromGLB"
-export {
-  renderGLTFToPNGBufferFromURL,
-  type RenderGLTFToPNGBufferFromURLOptions,
-} from "./render/renderGLTFToPNGBufferFromURL"
-export {
-  renderGLTFToPNGBufferFromGLBBuffer,
-  type RenderGLTFToPNGBufferFromGLBBufferOptions,
-} from "./render/renderGLTFToPNGBufferFromGLBBuffer"
-export {
-  renderGLTFToPNGBuffer,
-  type RenderGLTFToPNGBufferOptions,
-} from "./render/renderGLTFToPNGBuffer"
-
 export function renderSceneFromGLTF(
   scene: import("./gltf/types").GLTFScene,
   options?: import("./render/getDefaultRenderOptions").RenderOptionsInput,

--- a/tests/backward-compat/node-api.test.ts
+++ b/tests/backward-compat/node-api.test.ts
@@ -1,9 +1,7 @@
 import { expect, test } from "bun:test"
-import {
-  encodePNGToBuffer,
-  pureImageFactory,
-  renderGLTFToPNGBuffer,
-} from "../../lib"
+import { renderGLTFToPNGFromURL } from "../../lib"
+import { encodePNGToBuffer, pureImageFactory } from "../../cli"
+import { renderGLTFToPNGBuffer } from "../../cli/renderGLTFToPNGBuffer"
 
 const EMPTY_GLTF_JSON = JSON.stringify({
   asset: { version: "2.0" },
@@ -45,7 +43,7 @@ function createGLTFFetch() {
   }
 }
 
-test("root renderGLTFToPNGBuffer keeps supporting filesystem paths in Node", async () => {
+test("node renderGLTFToPNGBuffer keeps supporting filesystem paths", async () => {
   const pngBuffer = await renderGLTFToPNGBuffer("./tests/basics/soic8.gltf", {
     width: 96,
     height: 96,
@@ -54,23 +52,20 @@ test("root renderGLTFToPNGBuffer keeps supporting filesystem paths in Node", asy
   expectPngBuffer(pngBuffer, 100)
 })
 
-test("root renderGLTFToPNGBuffer forwards custom fetch for URL inputs", async () => {
+test("universal URL renderer forwards custom fetch", async () => {
   const gltfFetch = createGLTFFetch()
 
-  const pngBuffer = await renderGLTFToPNGBuffer(
-    "https://example.test/model.gltf",
-    {
-      width: 16,
-      height: 16,
-      fetchImpl: gltfFetch.fetchImpl,
-    },
-  )
+  const png = await renderGLTFToPNGFromURL("https://example.test/model.gltf", {
+    width: 16,
+    height: 16,
+    fetchImpl: gltfFetch.fetchImpl,
+  })
 
   expect(gltfFetch.fetchedURL).toBe("https://example.test/model.gltf")
-  expectPngBuffer(pngBuffer)
+  expectPngSignature(png)
 })
 
-test("root renderGLTFToPNGBuffer accepts GLTF JSON strings", async () => {
+test("node renderGLTFToPNGBuffer accepts GLTF JSON strings", async () => {
   const pngBuffer = await renderGLTFToPNGBuffer(EMPTY_GLTF_JSON, {
     width: 16,
     height: 16,

--- a/tests/basics/lib-entrypoint.test.ts
+++ b/tests/basics/lib-entrypoint.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import { fileURLToPath } from "node:url"
-import { renderGLTFToPNGBuffer } from "../../lib"
+import { renderGLTFToPNGBuffer } from "../../cli/renderGLTFToPNGBuffer"
 import "../fixtures/preload.ts"
 
 test("lib renderGLTFToPNGBuffer renders filesystem paths", async () => {


### PR DESCRIPTION
## Summary

Fixes browser 3D PNG rendering by removing Node-only rendering APIs from PoppyGL's root entrypoint.

## Problem

Importing `poppygl` in the browser included Node-specific buffer-rendering exports and their PureImage/stream dependency chain. This caused browser 3D PNG downloads to fail while dynamically loading PoppyGL through jscdn.

## Changes

- Remove Node-only buffer-rendering exports from the root module.
- Keep the public root API focused on portable `Uint8Array` rendering APIs.
- Route custom-fetch coverage through the universal URL renderer.
- Retain the Node CLI renderer internally for filesystem-based workflows.
- Update documentation to use `createUint8Bitmap` and `encodePNG`.

## Impact

Browser consumers can dynamically import PoppyGL without loading Node-only renderer exports. This restores the 3D PNG download path and keeps the default API portable across browsers, Bun, and edge runtimes.

## Validation

- `bun test` — 21 passing
- `bun run build`
- `bun run format:check`
- `bun run test:playwright` — browser rendering passes with no Node globals
